### PR TITLE
fix: error message on WOL success

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,8 @@
 name: Docker
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   docker-build:

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,7 +198,7 @@ fn MainView(cx: Scope) -> impl IntoView {
                                 "Magic packet was sent. Please wait for the computer to wake up."
                             </div>
                         })
-                    } else {
+                    } else if !success {
                         Some(view! {
                             cx,
                             <div class="text-lg error p-2 rounded-lg text-center">
@@ -206,6 +206,8 @@ fn MainView(cx: Scope) -> impl IntoView {
                                 {wakeup_error}
                             </div>
                         })
+                    } else {
+                        None
                     }
                 })}
             }


### PR DESCRIPTION
A logical error was causing the error message to show upon WOL success (when the machine comes online after a command was sent).